### PR TITLE
Add compatibility with php8 to phpunit 7

### DIFF
--- a/src/Framework/MockObject/Builder/NamespaceMatch.php
+++ b/src/Framework/MockObject/Builder/NamespaceMatch.php
@@ -21,7 +21,7 @@ interface NamespaceMatch
      *
      * @param string $id The identification of the match builder
      *
-     * @return Match
+     * @return OrderMatch
      */
     public function lookupId($id);
 
@@ -30,8 +30,8 @@ interface NamespaceMatch
      * builder can later be looked up using lookupId() to figure out if it
      * has been invoked.
      *
-     * @param string $id      The identification of the match builder
-     * @param Match  $builder The builder which is being registered
+     * @param string     $id      The identification of the match builder
+     * @param OrderMatch $builder The builder which is being registered
      */
-    public function registerId($id, Match $builder);
+    public function registerId($id, OrderMatch $builder);
 }

--- a/src/Framework/MockObject/Builder/OrderMatch.php
+++ b/src/Framework/MockObject/Builder/OrderMatch.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Framework\MockObject\Builder;
 /**
  * Builder interface for invocation order matches.
  */
-interface Match extends Stub
+interface OrderMatch extends Stub
 {
     /**
      * Defines the expectation which must occur before the current is valid.

--- a/src/Framework/MockObject/Builder/ParametersMatch.php
+++ b/src/Framework/MockObject/Builder/ParametersMatch.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\MockObject\Matcher\AnyParameters;
 /**
  * Builder interface for parameter matchers.
  */
-interface ParametersMatch extends Match
+interface ParametersMatch extends OrderMatch
 {
     /**
      * Sets the parameters to match for, each parameter to this function will

--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Framework\MockObject;
 use Exception;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMocker;
-use PHPUnit\Framework\MockObject\Builder\Match;
+use PHPUnit\Framework\MockObject\Builder\OrderMatch;
 use PHPUnit\Framework\MockObject\Builder\NamespaceMatch;
 use PHPUnit\Framework\MockObject\Matcher\DeferredError;
 use PHPUnit\Framework\MockObject\Matcher\Invocation as MatcherInvocation;
@@ -33,7 +33,7 @@ class InvocationMocker implements Invokable, MatcherCollection, NamespaceMatch
     private $matchers = [];
 
     /**
-     * @var Match[]
+     * @var OrderMatch[]
      */
     private $builderMap = [];
 
@@ -82,7 +82,7 @@ class InvocationMocker implements Invokable, MatcherCollection, NamespaceMatch
     /**
      * @throws RuntimeException
      */
-    public function registerId($id, Match $builder): void
+    public function registerId($id, OrderMatch $builder): void
     {
         if (isset($this->builderMap[$id])) {
             throw new RuntimeException(

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -305,7 +305,9 @@ final class MockMethod
                     $typeDeclaration = $parameter->getType()->getName() . ' ';
                 } else {
                     try {
-                        $class = $parameter->getClass();
+                        $class = $parameter->getType() && !$parameter->getType()->isBuiltin()
+                            ? new ReflectionClass($parameter->getType()->getName())
+                            : null;
                     } catch (ReflectionException $e) {
                         throw new RuntimeException(
                             \sprintf(

--- a/src/Runner/Version.php
+++ b/src/Runner/Version.php
@@ -30,7 +30,7 @@ class Version
         }
 
         if (self::$version === null) {
-            $version       = new VersionId('7.5.20', \dirname(__DIR__, 2));
+            $version       = new VersionId('7.5.20.PHP-8', \dirname(__DIR__, 2));
             self::$version = $version->getVersion();
         }
 


### PR DESCRIPTION
This pull request adds compatibility with PHP 8 to version 7.5 of PHPUnit. The things that needed changes are:

* [`ReflectionMethod::getClass` is deprecated](https://php.watch/versions/8.0/deprecated-reflectionparameter-methods). It's been replaced with `ReflectionMethod::getType`.
* [`match` is now a reserved keyword](https://stitcher.io/blog/php-8-match-or-switch), therefore the `Match` class had to be renamed.